### PR TITLE
Whitelisted kuaidi100.com and needed subdomains

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -44,3 +44,7 @@ vanilla.futurecdn.net
 graph.facebook.com
 facebook.com
 www.facebook.com
+kuaidi100.com
+www.kuaidi100.com
+cdn.kuaidi100.com
+m.kuaidi100.com


### PR DESCRIPTION
Whitelisted:
kuaidi100.com
www.kuaidi100.com
cdn.kuaidi100.com
m.kuaidi100.com